### PR TITLE
link changed to week 2 from week3 in Andrew NG course suggestion

### DIFF
--- a/2022-10-19-recommenders-1.md
+++ b/2022-10-19-recommenders-1.md
@@ -47,7 +47,7 @@ Suggested materials
 
 * 🗒️ [Background section of Google Recommendation systems course](https://developers.google.com/machine-learning/recommendation)
 * 🏫 [ML Zoomcamp - EDA section](https://github.com/alexeygrigorev/mlbookcamp-code/blob/master/course-zoomcamp/02-regression/03-eda.md)
-* 🏫 [Andrew NG - New ML Specialization on Coursera ](https://www.coursera.org/learn/unsupervised-learning-recommenders-reinforcement-learning/home/week/3)
+* 🏫 [Andrew NG - New ML Specialization on Coursera ](https://www.coursera.org/learn/unsupervised-learning-recommenders-reinforcement-learning/home/week/2)
 
 Found good materials? Create a PR with links!
 


### PR DESCRIPTION
link changed to week 2 from week3 in Andrew NG course suggestion . Sorry , the last link was pointing to week3 whereas week2 covers recommendation systems . Fixed the url . Please merge.